### PR TITLE
refactor(medkb): collapse graded_chunks into retrieved_chunks

### DIFF
--- a/services/medkb/src/medkb/graph/nodes/grade.py
+++ b/services/medkb/src/medkb/graph/nodes/grade.py
@@ -55,7 +55,7 @@ async def grade_docs_node(state: RAGState) -> dict:
         len(graded), len(chunks), doc_grade,
     )
     return {
-        "graded_chunks": graded,
+        "retrieved_chunks": graded,
         "doc_grade": doc_grade,
         "tokens_used": total_tokens,
     }

--- a/services/medkb/src/medkb/graph/state.py
+++ b/services/medkb/src/medkb/graph/state.py
@@ -34,7 +34,6 @@ class RAGState(TypedDict, total=False):
     config: RAGConfig
 
     retrieved_chunks: list[RetrievedChunk]
-    graded_chunks: list[RetrievedChunk]
     doc_grade: str
     rewrite_count: int
     regenerated: bool
@@ -66,7 +65,6 @@ def make_initial_state(
         caller_id=caller_id,
         config=config,
         retrieved_chunks=[],
-        graded_chunks=[],
         doc_grade="",
         rewrite_count=0,
         regenerated=False,

--- a/services/medkb/tests/test_grade.py
+++ b/services/medkb/tests/test_grade.py
@@ -34,7 +34,7 @@ async def test_grade_returns_good_for_relevant_chunks():
 
         result = await grade_docs_node(state)
         assert result["doc_grade"] == "good"
-        assert len(result["graded_chunks"]) == 1
+        assert len(result["retrieved_chunks"]) == 1
 
 
 @pytest.mark.asyncio
@@ -65,4 +65,4 @@ async def test_grade_returns_bad_for_irrelevant_chunks():
 
         result = await grade_docs_node(state)
         assert result["doc_grade"] == "bad"
-        assert len(result["graded_chunks"]) == 0
+        assert len(result["retrieved_chunks"]) == 0

--- a/services/medkb/tests/test_graph_crag.py
+++ b/services/medkb/tests/test_graph_crag.py
@@ -58,6 +58,80 @@ async def test_crag_strategy_grades_and_generates():
 
 
 @pytest.mark.asyncio
+async def test_crag_filters_irrelevant_chunks_before_generation():
+    """Verify grade filtering is actually honored by generate (not a no-op)."""
+    good = RetrievedChunk(
+        chunk_id="g1", document_id="d1", corpus_id="corp1",
+        text="KEYNOTE-024 showed superior PFS for pembrolizumab.",
+        section="results", metadata={"title": "Good"},
+        retriever_source="pgvector", raw_score=0.9, fusion_rank=1,
+    )
+    bad = RetrievedChunk(
+        chunk_id="b1", document_id="d2", corpus_id="corp1",
+        text="Marketing event planning guide.",
+        section=None, metadata={"title": "Bad"},
+        retriever_source="pgvector", raw_score=0.3, fusion_rank=2,
+    )
+    mock_retriever = AsyncMock()
+    mock_retriever.name = "pgvector"
+    mock_retriever.retrieve = AsyncMock(return_value=[good, bad])
+
+    grade_responses = [
+        MagicMock(content="relevant", usage_metadata={"input_tokens": 200, "output_tokens": 5}),
+        MagicMock(content="not_relevant", usage_metadata={"input_tokens": 200, "output_tokens": 5}),
+    ]
+    gen_response = MagicMock()
+    gen_response.content = "Answer cites only the relevant document."
+    gen_response.usage_metadata = {"input_tokens": 500, "output_tokens": 50}
+
+    graph = build_rag_graph()
+    config = RAGConfig(
+        strategy="crag", corpora=["test"], k=8,
+        generate_answer=True, generation_model="claude-sonnet-4-6",
+        grader_model="ollama:qwen3:14b", max_retries=2,
+        include_citations=True, max_total_tokens=50000,
+    )
+    state = make_initial_state(
+        query="pembrolizumab outcomes", config=config,
+        run_id="run-1", caller_id="test",
+    )
+    state["_retrievers"] = [mock_retriever]
+
+    captured_gen_messages = []
+
+    async def gen_side_effect(messages):
+        captured_gen_messages.append(messages)
+        return gen_response
+
+    with patch("medkb.graph.nodes.grade.get_llm") as mock_grade_llm, \
+         patch("medkb.graph.nodes.generate.get_llm") as mock_gen_llm:
+
+        grade_llm = AsyncMock()
+        grade_llm.ainvoke = AsyncMock(side_effect=grade_responses)
+        mock_grade_llm.return_value = grade_llm
+
+        gen_llm = AsyncMock()
+        gen_llm.ainvoke = AsyncMock(side_effect=gen_side_effect)
+        mock_gen_llm.return_value = gen_llm
+
+        result = await graph.ainvoke(state)
+
+    assert result["doc_grade"] == "good"
+    assert len(result["retrieved_chunks"]) == 1
+    assert result["retrieved_chunks"][0].chunk_id == "g1"
+
+    # Generate must have received the filtered context (good doc only, not bad).
+    assert len(captured_gen_messages) == 1
+    human_content = captured_gen_messages[0][1].content
+    assert "KEYNOTE-024" in human_content
+    assert "Marketing event planning" not in human_content
+
+    # Citations must only include the relevant chunk.
+    assert len(result["citations"]) == 1
+    assert result["citations"][0]["chunk_id"] == "g1"
+
+
+@pytest.mark.asyncio
 async def test_crag_rewrites_on_bad_grade():
     bad_chunk = RetrievedChunk(
         chunk_id="c1", document_id="d1", corpus_id="corp1",


### PR DESCRIPTION
## Summary

The CRAG graph mutates `retrieved_chunks` in place, so the separate `graded_chunks` field on `RAGState` was redundant — `grade_docs_node` writes the filtered list back into `retrieved_chunks` instead of a second field.

- `state.py` — drop `graded_chunks` field from `RAGState` and `make_initial_state`
- `grade.py` — return `retrieved_chunks` (filtered) instead of `graded_chunks`
- `test_grade.py` — assertions updated to read `result["retrieved_chunks"]`
- `test_graph_crag.py` — adds `test_crag_filters_irrelevant_chunks_before_generation` as a regression guard

The new test verifies end-to-end that when the grader marks a chunk `not_relevant`:
1. It is removed from `retrieved_chunks`
2. `generate` receives only the relevant chunk's text (the bad chunk's text is not present in the human message)
3. The citations list contains only the relevant `chunk_id`

## Test plan

- [ ] `pytest services/medkb/tests/test_grade.py` passes
- [ ] `pytest services/medkb/tests/test_graph_crag.py` passes
- [ ] No other callers of `graded_chunks` exist (`grep -r graded_chunks services/medkb` should return nothing after merge)

Merge with `--no-ff` to preserve the merge commit for revertability.