### PR TITLE
feat: registry upsert/idempotency + dev_changelog KB source

### DIFF
--- a/registry/alembic/versions/021_add_upsert_constraints.py
+++ b/registry/alembic/versions/021_add_upsert_constraints.py
@@ -1,0 +1,59 @@
+"""Add unique constraints for upsert idempotency on 4 KB tables
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-05-15
+
+Adds DB-level unique constraints as safety nets for app-level upsert logic.
+Also adds upsert_key_hash column to corrections (MD5 of user_message) since
+user_message is TEXT and can't participate in a btree index directly.
+
+Keys:
+  decision_logs:  (project_name, title)
+  insights:       (project_name, tldr)
+  ship_sessions:  (project_name, left(feature, 255))  — functional index for TEXT col
+  corrections:    (project_name, category, upsert_key_hash)
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "021"
+down_revision = "020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- corrections: add hash column, backfill, make NOT NULL ---
+    op.add_column("corrections", sa.Column("upsert_key_hash", sa.String(32), nullable=True))
+    op.execute("UPDATE corrections SET upsert_key_hash = md5(user_message) WHERE upsert_key_hash IS NULL")
+    op.alter_column("corrections", "upsert_key_hash", nullable=False)
+
+    # --- unique constraints ---
+    op.create_unique_constraint(
+        "uq_decision_logs_project_title", "decision_logs", ["project_name", "title"],
+    )
+    op.create_unique_constraint(
+        "uq_insights_project_tldr", "insights", ["project_name", "tldr"],
+    )
+    op.create_unique_constraint(
+        "uq_corrections_project_cat_hash", "corrections",
+        ["project_name", "category", "upsert_key_hash"],
+    )
+    # ship_sessions.feature is TEXT — use functional index to stay within btree limits
+    op.execute("""
+        CREATE UNIQUE INDEX uq_ship_sessions_project_feature
+        ON ship_sessions (project_name, left(feature, 255))
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_ship_sessions_project_feature")
+    op.drop_constraint("uq_corrections_project_cat_hash", "corrections", type_="unique")
+    op.drop_constraint("uq_insights_project_tldr", "insights", type_="unique")
+    op.drop_constraint("uq_decision_logs_project_title", "decision_logs", type_="unique")
+    op.alter_column("corrections", "upsert_key_hash", nullable=True)
+    op.drop_column("corrections", "upsert_key_hash")

--- a/registry/alembic/versions/022_add_dev_changelog_kb.py
+++ b/registry/alembic/versions/022_add_dev_changelog_kb.py
@@ -1,0 +1,84 @@
+"""Add KB search infrastructure to dev_changelog
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-05-15
+
+Adds project_name, search_vector, embedding columns to dev_changelog so it
+can participate in the unified KB search endpoint as the 7th source.
+Backfills search_vector for existing 16 rows.
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from pgvector.sqlalchemy import Vector
+
+
+revision = "022"
+down_revision = "021"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # --- new columns ---
+    op.add_column("dev_changelog", sa.Column(
+        "project_name", sa.String(100), nullable=False, server_default="shared",
+    ))
+    op.add_column("dev_changelog", sa.Column(
+        "search_vector", postgresql.TSVECTOR, nullable=True,
+    ))
+    op.add_column("dev_changelog", sa.Column(
+        "embedding", Vector(768), nullable=True,
+    ))
+    op.add_column("dev_changelog", sa.Column(
+        "embedding_model", sa.String(64), nullable=True,
+    ))
+
+    # --- indexes ---
+    op.create_index("ix_dev_changelog_project_name", "dev_changelog", ["project_name"])
+    op.create_index("ix_dev_changelog_search", "dev_changelog", ["search_vector"],
+                    postgresql_using="gin")
+
+    # --- trigger: auto-populate search_vector on INSERT/UPDATE ---
+    op.execute("""
+        CREATE OR REPLACE FUNCTION dev_changelog_search_vector_update()
+        RETURNS trigger AS $$
+        BEGIN
+            NEW.search_vector := to_tsvector('english',
+                coalesce(NEW.epic, '') || ' ' ||
+                coalesce(NEW.key_insight, '') || ' ' ||
+                coalesce(NEW.notes, '') || ' ' ||
+                coalesce(NEW.category, '')
+            );
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER dev_changelog_search_vector_trigger
+            BEFORE INSERT OR UPDATE ON dev_changelog
+            FOR EACH ROW EXECUTE FUNCTION dev_changelog_search_vector_update();
+    """)
+
+    # --- backfill search_vector for existing rows ---
+    op.execute("""
+        UPDATE dev_changelog SET search_vector = to_tsvector('english',
+            coalesce(epic, '') || ' ' ||
+            coalesce(key_insight, '') || ' ' ||
+            coalesce(notes, '') || ' ' ||
+            coalesce(category, '')
+        )
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP TRIGGER IF EXISTS dev_changelog_search_vector_trigger ON dev_changelog;")
+    op.execute("DROP FUNCTION IF EXISTS dev_changelog_search_vector_update();")
+    op.drop_index("ix_dev_changelog_search", table_name="dev_changelog")
+    op.drop_index("ix_dev_changelog_project_name", table_name="dev_changelog")
+    op.drop_column("dev_changelog", "embedding_model")
+    op.drop_column("dev_changelog", "embedding")
+    op.drop_column("dev_changelog", "search_vector")
+    op.drop_column("dev_changelog", "project_name")

--- a/registry/corrections_endpoints.py
+++ b/registry/corrections_endpoints.py
@@ -10,14 +10,17 @@ The corrections table captures user pushback patterns so Claude can learn
 what behaviors to avoid. Queryable via the unified KB search endpoint and
 surfaced in SessionStart briefing Section 8.
 """
+import hashlib
 import os
 import sys
 import time
 import logging
 from datetime import datetime, timedelta, timezone
 from typing import Optional
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy import func as sa_func
 
@@ -67,9 +70,68 @@ except ImportError:
 router = APIRouter(prefix="/api/corrections", tags=["corrections"])
 
 
+def _compute_upsert_hash(user_message: str) -> str:
+    return hashlib.md5(user_message.encode("utf-8")).hexdigest()
+
+
+def _upsert_correction(
+    db: Session, payload: CorrectionCreate, upsert_hash: str, embedding=None,
+) -> tuple[Correction, bool]:
+    """Upsert by (project_name, category, upsert_key_hash). Returns (row, created)."""
+    existing = db.query(Correction).filter(
+        Correction.project_name == payload.project_name,
+        Correction.category == payload.category,
+        Correction.upsert_key_hash == upsert_hash,
+    ).first()
+
+    if existing:
+        existing.user_message = payload.user_message
+        existing.context = payload.context
+        existing.claude_action = payload.claude_action
+        existing.session_id = payload.session_id
+        existing.tags = payload.tags
+        existing.model_name = payload.model_name
+        existing.meta_data = payload.meta_data
+        if embedding:
+            existing.embedding = embedding
+            existing.embedding_model = "nomic-embed-text"
+        return existing, False
+
+    row = Correction(**payload.model_dump())
+    row.upsert_key_hash = upsert_hash
+    if embedding:
+        row.embedding = embedding
+        row.embedding_model = "nomic-embed-text"
+    try:
+        db.add(row)
+        db.flush()
+        return row, True
+    except IntegrityError:
+        db.rollback()
+        existing = db.query(Correction).filter(
+            Correction.project_name == payload.project_name,
+            Correction.category == payload.category,
+            Correction.upsert_key_hash == upsert_hash,
+        ).first()
+        if existing:
+            existing.user_message = payload.user_message
+            existing.context = payload.context
+            existing.claude_action = payload.claude_action
+            existing.session_id = payload.session_id
+            existing.tags = payload.tags
+            existing.model_name = payload.model_name
+            existing.meta_data = payload.meta_data
+            if embedding:
+                existing.embedding = embedding
+                existing.embedding_model = "nomic-embed-text"
+            return existing, False
+        raise
+
+
 @router.post("", response_model=CorrectionResponse, status_code=201)
 async def create_correction(
     payload: CorrectionCreate,
+    response: Response,
     db: Session = Depends(get_db),
 ):
     start = time.time()
@@ -79,19 +141,21 @@ async def create_correction(
             detail=f"Invalid category '{payload.category}'. Valid: {sorted(VALID_CATEGORIES)}",
         )
     try:
-        row = Correction(**payload.model_dump())
+        upsert_hash = _compute_upsert_hash(payload.user_message)
+
+        embedding = None
         try:
             embed_text = f"{payload.category} {payload.user_message} {payload.context or ''}"
             embedding = await get_embedding(embed_text)
-            if embedding:
-                row.embedding = embedding
-                row.embedding_model = "nomic-embed-text"
         except Exception as embed_err:
             logger.warning("Correction embedding failed: %s", embed_err)
 
-        db.add(row)
+        row, created = _upsert_correction(db, payload, upsert_hash, embedding)
         db.commit()
         db.refresh(row)
+
+        if not created:
+            response.status_code = 200
 
         registry_write_operations.labels(operation="create_correction").inc()
         registry_write_latency.observe((time.time() - start) * 1000)
@@ -101,7 +165,8 @@ async def create_correction(
     except Exception as e:
         db.rollback()
         registry_errors.labels(error_type="create_correction_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "corrections_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("", response_model=CorrectionList)
@@ -133,7 +198,8 @@ async def list_corrections(
         return CorrectionList(corrections=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="list_corrections_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "corrections_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/search", response_model=CorrectionList)
@@ -162,7 +228,8 @@ async def search_corrections(
         return CorrectionList(corrections=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="search_corrections_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "corrections_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("/stats")
@@ -196,4 +263,25 @@ async def correction_stats(
         }
     except Exception as e:
         registry_errors.labels(error_type="correction_stats_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "corrections_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/{item_id}", status_code=204)
+async def delete_correction(
+    item_id: UUID,
+    db: Session = Depends(get_db),
+):
+    try:
+        row = db.query(Correction).filter(Correction.id == item_id).first()
+        if not row:
+            raise HTTPException(status_code=404, detail="Not found")
+        db.delete(row)
+        db.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        registry_errors.labels(error_type="delete_correction_failed").inc()
+        logger.error("delete_correction failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/registry/corrections_schemas.py
+++ b/registry/corrections_schemas.py
@@ -38,6 +38,7 @@ class CorrectionResponse(BaseModel):
     project_name: str
     category: str
     user_message: str
+    upsert_key_hash: str
     context: Optional[str]
     claude_action: Optional[str]
     session_id: Optional[str]

--- a/registry/decision_logs_endpoints.py
+++ b/registry/decision_logs_endpoints.py
@@ -10,8 +10,10 @@ import sys
 import time
 import logging
 from typing import Optional
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy import func as sa_func
 
@@ -59,28 +61,85 @@ except ImportError:
 router = APIRouter(prefix="/api/decision-logs", tags=["decision-logs"])
 
 
+def _upsert_decision_log(
+    db: Session, payload: DecisionLogCreate, embedding=None,
+) -> tuple[DecisionLog, bool]:
+    """Upsert by (project_name, title). Returns (row, created)."""
+    existing = db.query(DecisionLog).filter(
+        DecisionLog.project_name == payload.project_name,
+        DecisionLog.title == payload.title,
+    ).first()
+
+    if existing:
+        existing.choice = payload.choice
+        existing.alternatives_rejected = payload.alternatives_rejected
+        existing.rationale = payload.rationale
+        existing.domain = payload.domain
+        existing.supersedes = payload.supersedes
+        existing.source_file = payload.source_file
+        existing.tags = payload.tags
+        existing.session_id = payload.session_id
+        existing.model_name = payload.model_name
+        existing.meta_data = payload.meta_data
+        if embedding:
+            existing.embedding = embedding
+            existing.embedding_model = "nomic-embed-text"
+        return existing, False
+
+    row = DecisionLog(**payload.model_dump())
+    if embedding:
+        row.embedding = embedding
+        row.embedding_model = "nomic-embed-text"
+    try:
+        db.add(row)
+        db.flush()
+        return row, True
+    except IntegrityError:
+        db.rollback()
+        existing = db.query(DecisionLog).filter(
+            DecisionLog.project_name == payload.project_name,
+            DecisionLog.title == payload.title,
+        ).first()
+        if existing:
+            existing.choice = payload.choice
+            existing.alternatives_rejected = payload.alternatives_rejected
+            existing.rationale = payload.rationale
+            existing.domain = payload.domain
+            existing.supersedes = payload.supersedes
+            existing.source_file = payload.source_file
+            existing.tags = payload.tags
+            existing.session_id = payload.session_id
+            existing.model_name = payload.model_name
+            existing.meta_data = payload.meta_data
+            if embedding:
+                existing.embedding = embedding
+                existing.embedding_model = "nomic-embed-text"
+            return existing, False
+        raise
+
+
 @router.post("", response_model=DecisionLogResponse, status_code=status.HTTP_201_CREATED)
 async def create_decision_log(
     payload: DecisionLogCreate,
+    response: Response,
     db: Session = Depends(get_db),
 ) -> DecisionLogResponse:
     start = time.time()
     try:
-        row = DecisionLog(**payload.model_dump())
-
+        embedding = None
         try:
             from embedding_utils import get_embedding
             text_for_embed = f"{payload.title} {payload.choice} {payload.rationale}"
             embedding = await get_embedding(text_for_embed)
-            if embedding:
-                row.embedding = embedding
-                row.embedding_model = "nomic-embed-text"
         except Exception as embed_err:
             logger.warning("Embedding generation failed: %s", embed_err)
 
-        db.add(row)
+        row, created = _upsert_decision_log(db, payload, embedding)
         db.commit()
         db.refresh(row)
+
+        if not created:
+            response.status_code = status.HTTP_200_OK
 
         registry_write_operations.labels(operation="create_decision_log").inc()
         registry_write_latency.observe((time.time() - start) * 1000)
@@ -90,7 +149,8 @@ async def create_decision_log(
     except Exception as e:
         db.rollback()
         registry_errors.labels(error_type="create_decision_log_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("create_decision_log failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("", response_model=DecisionLogList)
@@ -123,7 +183,8 @@ async def list_decision_logs(
         return DecisionLogList(decision_logs=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="list_decision_logs_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "decision_logs_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/search", response_model=DecisionLogList)
@@ -156,4 +217,25 @@ async def search_decision_logs(
         return DecisionLogList(decision_logs=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="search_decision_logs_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "decision_logs_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_decision_log(
+    item_id: UUID,
+    db: Session = Depends(get_db),
+):
+    try:
+        row = db.query(DecisionLog).filter(DecisionLog.id == item_id).first()
+        if not row:
+            raise HTTPException(status_code=404, detail="Not found")
+        db.delete(row)
+        db.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        registry_errors.labels(error_type="delete_decision_log_failed").inc()
+        logger.error("delete_decision_log failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/registry/doc_pages_endpoints.py
+++ b/registry/doc_pages_endpoints.py
@@ -14,6 +14,7 @@ import logging
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy import func as sa_func, text, tuple_ as sa_tuple
 
@@ -99,8 +100,32 @@ def _upsert_page(db: Session, page: DocPageCreate, embedding: Optional[list] = N
     if embedding:
         row.embedding = embedding
         row.embedding_model = "nomic-embed-text"
-    db.add(row)
-    return row, True
+    try:
+        db.add(row)
+        db.flush()
+        return row, True
+    except IntegrityError:
+        db.rollback()
+        existing = (
+            db.query(DocPage)
+            .filter(
+                DocPage.project_name == page.project_name,
+                DocPage.source_file == page.source_file,
+                DocPage.chunk_index == page.chunk_index,
+            )
+            .first()
+        )
+        if existing:
+            existing.title = page.title
+            existing.content = page.content
+            existing.heading_path = page.heading_path
+            existing.tags = page.tags
+            existing.meta_data = page.meta_data
+            if embedding:
+                existing.embedding = embedding
+                existing.embedding_model = "nomic-embed-text"
+            return existing, False
+        raise
 
 
 @router.post("", response_model=DocPageResponse, status_code=status.HTTP_201_CREATED)

--- a/registry/insights_endpoints.py
+++ b/registry/insights_endpoints.py
@@ -10,8 +10,10 @@ import sys
 import time
 import logging
 from typing import Optional
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy import func as sa_func
 
@@ -59,28 +61,85 @@ except ImportError:
 router = APIRouter(prefix="/api/insights", tags=["insights"])
 
 
+def _upsert_insight(
+    db: Session, payload: InsightCreate, embedding=None,
+) -> tuple[Insight, bool]:
+    """Upsert by (project_name, tldr). Returns (row, created)."""
+    existing = db.query(Insight).filter(
+        Insight.project_name == payload.project_name,
+        Insight.tldr == payload.tldr,
+    ).first()
+
+    if existing:
+        existing.insight_statement = payload.insight_statement
+        existing.category = payload.category
+        existing.subcategory = payload.subcategory
+        existing.source_file = payload.source_file
+        existing.source_language = payload.source_language
+        existing.source_framework = payload.source_framework
+        existing.tags = payload.tags
+        existing.session_id = payload.session_id
+        existing.model_name = payload.model_name
+        existing.meta_data = payload.meta_data
+        if embedding:
+            existing.embedding = embedding
+            existing.embedding_model = "nomic-embed-text"
+        return existing, False
+
+    row = Insight(**payload.model_dump())
+    if embedding:
+        row.embedding = embedding
+        row.embedding_model = "nomic-embed-text"
+    try:
+        db.add(row)
+        db.flush()
+        return row, True
+    except IntegrityError:
+        db.rollback()
+        existing = db.query(Insight).filter(
+            Insight.project_name == payload.project_name,
+            Insight.tldr == payload.tldr,
+        ).first()
+        if existing:
+            existing.insight_statement = payload.insight_statement
+            existing.category = payload.category
+            existing.subcategory = payload.subcategory
+            existing.source_file = payload.source_file
+            existing.source_language = payload.source_language
+            existing.source_framework = payload.source_framework
+            existing.tags = payload.tags
+            existing.session_id = payload.session_id
+            existing.model_name = payload.model_name
+            existing.meta_data = payload.meta_data
+            if embedding:
+                existing.embedding = embedding
+                existing.embedding_model = "nomic-embed-text"
+            return existing, False
+        raise
+
+
 @router.post("", response_model=InsightResponse, status_code=status.HTTP_201_CREATED)
 async def create_insight(
     payload: InsightCreate,
+    response: Response,
     db: Session = Depends(get_db),
 ) -> InsightResponse:
     start = time.time()
     try:
-        row = Insight(**payload.model_dump())
-
+        embedding = None
         try:
             from embedding_utils import get_embedding
             text_for_embed = f"{payload.tldr} {payload.insight_statement}"
             embedding = await get_embedding(text_for_embed)
-            if embedding:
-                row.embedding = embedding
-                row.embedding_model = "nomic-embed-text"
         except Exception as embed_err:
             logger.warning("Embedding generation failed: %s", embed_err)
 
-        db.add(row)
+        row, created = _upsert_insight(db, payload, embedding)
         db.commit()
         db.refresh(row)
+
+        if not created:
+            response.status_code = status.HTTP_200_OK
 
         registry_write_operations.labels(operation="create_insight").inc()
         registry_write_latency.observe((time.time() - start) * 1000)
@@ -90,7 +149,8 @@ async def create_insight(
     except Exception as e:
         db.rollback()
         registry_errors.labels(error_type="create_insight_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "insights_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("", response_model=InsightList)
@@ -123,7 +183,8 @@ async def list_insights(
         return InsightList(insights=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="list_insights_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "insights_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/search", response_model=InsightList)
@@ -156,4 +217,25 @@ async def search_insights(
         return InsightList(insights=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="search_insights_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "insights_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_insight(
+    item_id: UUID,
+    db: Session = Depends(get_db),
+):
+    try:
+        row = db.query(Insight).filter(Insight.id == item_id).first()
+        if not row:
+            raise HTTPException(status_code=404, detail="Not found")
+        db.delete(row)
+        db.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        registry_errors.labels(error_type="delete_insight_failed").inc()
+        logger.error("delete_insight failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")

--- a/registry/kb_endpoints.py
+++ b/registry/kb_endpoints.py
@@ -1,8 +1,9 @@
 """Unified Knowledge Base search endpoint.
 
 Routes:
-  POST /api/kb/search  — Hybrid FTS + vector RRF search across 4 tables, searched sequentially.
-                         Sources: doc_pages, insights, decision_logs, ship_sessions.
+  POST /api/kb/search  — Hybrid FTS + vector RRF search across 7 tables, searched sequentially.
+                         Sources: doc_pages, insights, decision_logs, ship_sessions,
+                         agent_sessions, corrections, dev_changelog.
 """
 import os
 import sys
@@ -17,7 +18,7 @@ from sqlalchemy import func as sa_func, text as sa_text
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from database import get_db
 from embedding_utils import get_embedding
-from models import DocPage, Insight, DecisionLog, ShipSession, Correction
+from models import DocPage, Insight, DecisionLog, ShipSession, Correction, AgentSession, DevChangelog
 from kb_schemas import KBSearchRequest, KBSearchResponse, KBSearchResult, VALID_SOURCES
 
 logger = logging.getLogger(__name__)
@@ -119,12 +120,45 @@ def _extract_correction(row: Correction) -> tuple[str, str, dict[str, Any]]:
     return title, content, metadata
 
 
+def _extract_agent_session(row: AgentSession) -> tuple[str, str, dict[str, Any]]:
+    title = row.tldr or (row.summary.split("\n")[0][:120] if row.summary else f"Session {row.session_id}")
+    content = row.summary or ""
+    metadata: dict[str, Any] = {
+        "project": row.project,
+        "source": row.source,
+        "session_id": row.session_id,
+        "model": row.model,
+        "skills_used": row.skills_used,
+        "branch": row.branch,
+    }
+    return title, content, metadata
+
+
+def _extract_dev_changelog(row: DevChangelog) -> tuple[str, str, dict[str, Any]]:
+    title = row.epic
+    parts = []
+    if row.key_insight:
+        parts.append(row.key_insight)
+    if row.notes:
+        parts.append(row.notes)
+    content = "\n\n".join(parts) if parts else row.epic
+    metadata: dict[str, Any] = {
+        "slug": row.slug,
+        "category": row.category,
+        "status": row.declared_status or row.detected_status,
+        "commit_count": row.commit_count,
+    }
+    return title, content, metadata
+
+
 _SOURCE_CONFIG: dict[str, tuple[Any, Callable]] = {
     "docs": (DocPage, _extract_doc_page),
     "insights": (Insight, _extract_insight),
     "decisions": (DecisionLog, _extract_decision_log),
     "ship_sessions": (ShipSession, _extract_ship_session),
     "corrections": (Correction, _extract_correction),
+    "agent_sessions": (AgentSession, _extract_agent_session),
+    "dev_changelog": (DevChangelog, _extract_dev_changelog),
 }
 
 

--- a/registry/kb_schemas.py
+++ b/registry/kb_schemas.py
@@ -5,7 +5,7 @@ from uuid import UUID
 from pydantic import BaseModel, ConfigDict, Field
 
 
-VALID_SOURCES = {"docs", "insights", "decisions", "ship_sessions", "corrections"}
+VALID_SOURCES = {"docs", "insights", "decisions", "ship_sessions", "corrections", "agent_sessions", "dev_changelog"}
 
 
 class KBSearchRequest(BaseModel):

--- a/registry/models.py
+++ b/registry/models.py
@@ -918,6 +918,10 @@ class DevChangelog(Base):
     priority = Column(Integer, nullable=True)
     locked = Column(Boolean, nullable=False, default=False)
     source = Column(String(20), nullable=False, default="manual")  # manual|agent|mixed
+    project_name = Column(String(100), nullable=False, server_default="shared")
+    search_vector = Column(TSVECTOR, nullable=True)
+    embedding = Column(Vector(768), nullable=True)
+    embedding_model = Column(String(64), nullable=True)
     detected_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
     last_agent_run_at = Column(DateTime(timezone=True), nullable=True)
     last_human_edit_at = Column(DateTime(timezone=True), nullable=True)
@@ -929,6 +933,8 @@ class DevChangelog(Base):
         Index("ix_dev_changelog_declared_status", "declared_status"),
         Index("ix_dev_changelog_category", "category"),
         Index("ix_dev_changelog_window_start", "window_start"),
+        Index("ix_dev_changelog_project_name", "project_name"),
+        Index("ix_dev_changelog_search", "search_vector", postgresql_using="gin"),
     )
 
 
@@ -1167,9 +1173,15 @@ class AgentSession(Base):
 
     meta_data = Column(JSONB, nullable=True)
 
+    project_name = Column(String(100), nullable=True)
+    embedding = Column(Vector(768), nullable=True)
+    embedding_model = Column(String(64), nullable=True)
+    search_vector = Column(TSVECTOR, nullable=True)
+
     __table_args__ = (
         Index("ix_agent_sessions_project_created", "project", "created_at"),
         Index("ix_agent_sessions_source", "source"),
+        Index("ix_agent_sessions_search", "search_vector", postgresql_using="gin"),
     )
 
 
@@ -1231,6 +1243,7 @@ class Insight(Base):
     updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
 
     __table_args__ = (
+        UniqueConstraint("project_name", "tldr", name="uq_insights_project_tldr"),
         Index("ix_insights_project_category", "project_name", "category"),
         Index("ix_insights_created", "created_at"),
         Index("ix_insights_tags", "tags", postgresql_using="gin"),
@@ -1267,6 +1280,7 @@ class DecisionLog(Base):
     embedding_model = Column(String(64), nullable=True)
 
     __table_args__ = (
+        UniqueConstraint("project_name", "title", name="uq_decision_logs_project_title"),
         Index("ix_decision_logs_project_domain", "project_name", "domain"),
         Index("ix_decision_logs_created", "created_at"),
         Index("ix_decision_logs_tags", "tags", postgresql_using="gin"),
@@ -1354,6 +1368,7 @@ class Correction(Base):
     project_name = Column(String(100), nullable=False)
     category = Column(String(64), nullable=False)
     user_message = Column(Text, nullable=False)
+    upsert_key_hash = Column(String(32), nullable=False)
     context = Column(Text, nullable=True)
     claude_action = Column(Text, nullable=True)
     session_id = Column(String(128), nullable=True)
@@ -1367,6 +1382,7 @@ class Correction(Base):
     updated_at = Column(DateTime(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False)
 
     __table_args__ = (
+        UniqueConstraint("project_name", "category", "upsert_key_hash", name="uq_corrections_project_cat_hash"),
         Index("ix_corrections_project_category", "project_name", "category"),
         Index("ix_corrections_created", "created_at"),
         Index("ix_corrections_tags", "tags", postgresql_using="gin"),

--- a/registry/ship_sessions_endpoints.py
+++ b/registry/ship_sessions_endpoints.py
@@ -10,8 +10,10 @@ import sys
 import time
 import logging
 from typing import Optional
+from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 from sqlalchemy import func as sa_func
 
@@ -59,28 +61,101 @@ except ImportError:
 router = APIRouter(prefix="/api/ship-sessions", tags=["ship-sessions"])
 
 
+def _upsert_ship_session(
+    db: Session, payload: ShipSessionCreate, embedding=None,
+) -> tuple[ShipSession, bool]:
+    """Upsert by (project_name, feature). Returns (row, created)."""
+    existing = db.query(ShipSession).filter(
+        ShipSession.project_name == payload.project_name,
+        ShipSession.feature == payload.feature,
+    ).first()
+
+    if existing:
+        existing.approach = payload.approach
+        existing.status = payload.status
+        existing.complexity = payload.complexity
+        existing.tdd = payload.tdd
+        existing.pr_url = payload.pr_url
+        existing.branch = payload.branch
+        existing.commits = payload.commits
+        existing.deferred = payload.deferred
+        existing.surprises = payload.surprises
+        existing.decisions = payload.decisions
+        existing.review = payload.review
+        existing.verification = payload.verification
+        existing.file_map = payload.file_map
+        existing.tags = payload.tags
+        existing.session_id = payload.session_id
+        existing.model_name = payload.model_name
+        existing.meta_data = payload.meta_data
+        existing.completed_at = payload.completed_at
+        if embedding:
+            existing.embedding = embedding
+            existing.embedding_model = "nomic-embed-text"
+        return existing, False
+
+    row = ShipSession(**payload.model_dump())
+    if embedding:
+        row.embedding = embedding
+        row.embedding_model = "nomic-embed-text"
+    try:
+        db.add(row)
+        db.flush()
+        return row, True
+    except IntegrityError:
+        db.rollback()
+        existing = db.query(ShipSession).filter(
+            ShipSession.project_name == payload.project_name,
+            ShipSession.feature == payload.feature,
+        ).first()
+        if existing:
+            existing.approach = payload.approach
+            existing.status = payload.status
+            existing.complexity = payload.complexity
+            existing.tdd = payload.tdd
+            existing.pr_url = payload.pr_url
+            existing.branch = payload.branch
+            existing.commits = payload.commits
+            existing.deferred = payload.deferred
+            existing.surprises = payload.surprises
+            existing.decisions = payload.decisions
+            existing.review = payload.review
+            existing.verification = payload.verification
+            existing.file_map = payload.file_map
+            existing.tags = payload.tags
+            existing.session_id = payload.session_id
+            existing.model_name = payload.model_name
+            existing.meta_data = payload.meta_data
+            existing.completed_at = payload.completed_at
+            if embedding:
+                existing.embedding = embedding
+                existing.embedding_model = "nomic-embed-text"
+            return existing, False
+        raise
+
+
 @router.post("", response_model=ShipSessionResponse, status_code=status.HTTP_201_CREATED)
 async def create_ship_session(
     payload: ShipSessionCreate,
+    response: Response,
     db: Session = Depends(get_db),
 ) -> ShipSessionResponse:
     start = time.time()
     try:
-        row = ShipSession(**payload.model_dump())
-
+        embedding = None
         try:
             from embedding_utils import get_embedding
             text_for_embed = f"{payload.feature} {payload.approach or ''}"
             embedding = await get_embedding(text_for_embed)
-            if embedding:
-                row.embedding = embedding
-                row.embedding_model = "nomic-embed-text"
         except Exception as embed_err:
             logger.warning("Embedding generation failed: %s", embed_err)
 
-        db.add(row)
+        row, created = _upsert_ship_session(db, payload, embedding)
         db.commit()
         db.refresh(row)
+
+        if not created:
+            response.status_code = status.HTTP_200_OK
 
         registry_write_operations.labels(operation="create_ship_session").inc()
         registry_write_latency.observe((time.time() - start) * 1000)
@@ -90,7 +165,8 @@ async def create_ship_session(
     except Exception as e:
         db.rollback()
         registry_errors.labels(error_type="create_ship_session_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "ship_sessions_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.get("", response_model=ShipSessionList)
@@ -123,7 +199,8 @@ async def list_ship_sessions(
         return ShipSessionList(ship_sessions=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="list_ship_sessions_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "ship_sessions_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 @router.post("/search", response_model=ShipSessionList)
@@ -156,4 +233,25 @@ async def search_ship_sessions(
         return ShipSessionList(ship_sessions=rows, total=total)
     except Exception as e:
         registry_errors.labels(error_type="search_ship_sessions_failed").inc()
-        raise HTTPException(status_code=500, detail=str(e))
+        logger.error("%s failed: %s", "ship_sessions_op", e)
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@router.delete("/{item_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_ship_session(
+    item_id: UUID,
+    db: Session = Depends(get_db),
+):
+    try:
+        row = db.query(ShipSession).filter(ShipSession.id == item_id).first()
+        if not row:
+            raise HTTPException(status_code=404, detail="Not found")
+        db.delete(row)
+        db.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        db.rollback()
+        registry_errors.labels(error_type="delete_ship_session_failed").inc()
+        logger.error("delete_ship_session failed: %s", e)
+        raise HTTPException(status_code=500, detail="Internal server error")


### PR DESCRIPTION
## Summary
- Add idempotent upsert behavior to 4 KB tables (decision_logs, insights, ship_sessions, corrections) with DB unique constraints and app-level TOCTOU fallback
- Add dev_changelog as 7th unified KB source (16 rows of curated engineering history, FTS + embedding ready)
- Add DELETE endpoints for all 4 tables with proper error handling
- Fix doc_pages existing TOCTOU gap, mask internal error details in all error responses
- Clean up 6 semantic duplicate decisions

## Changes
- **Migrations:** 021 (4 unique constraints + upsert_key_hash column), 022 (dev_changelog KB columns + trigger + backfill)
- **Endpoints:** Upsert pattern on POST (200 update / 201 create), DELETE with try/except, masked error messages
- **Models:** UniqueConstraints reflected in SQLAlchemy __table_args__ for DecisionLog, Insight, Correction
- **KB search:** 7 sources (docs, insights, decisions, ship_sessions, agent_sessions, corrections, dev_changelog)

## Verification
- All 4 upserts: 201 create, 200 update, 1 row maintained
- dev_changelog KB search returns results (FTS verified)
- Idempotency: ingest-memory-files.py x2 = same counts
- DELETE endpoints return 204 on success, 404 on missing
- API healthy after deploy

## Test plan
- [ ] POST same decision twice → 201 then 200, same id
- [ ] POST same insight twice → 201 then 200, same id
- [ ] POST same ship_session twice → 201 then 200, same id
- [ ] POST same correction twice → 201 then 200, same id
- [ ] DELETE existing → 204, DELETE missing → 404
- [ ] KB search with dev_changelog source → results returned
- [ ] Run ingest scripts twice → no duplicate rows

## Deferred
- dev_changelog embedding backfill (16 rows need Ollama vectors)
- Incidents table KB integration (99% alert noise)
- incident_postmortems KB integration (1 row exists)
- Cron job for periodic re-ingest of memory files

🤖 Generated with [Claude Code](https://claude.com/claude-code)