### PR TITLE
Cap Explore subagent handback to a summary, not source dumps

### DIFF
--- a/.claude/rules/codegraph.md
+++ b/.claude/rules/codegraph.md
@@ -21,3 +21,5 @@ The graphify hooks are scoped to source-code paths only — grepping or reading 
 ---
 
 Which CodeGraph calls are main-session-safe (`_search`/`_node`/`_callers`/`_impact`) vs Explore-subagent-only (`_explore`/`_context`), the Explore-subagent decision table, and the FileWatcher/`codegraph sync` details all live in the global CLAUDE.md CodeGraph section — not duplicated here.
+
+**Explore handback contract:** an Explore subagent's final message must be a summary — `file:line` citations, not `codegraph_explore` / `codegraph_context` source dumps. Echoing retrieved source back into the main session is what causes the post-Explore stall. The full contract lives in the `codegraph-explore` skill's "What to report back" section.

--- a/.claude/skills/codegraph-explore/SKILL.md
+++ b/.claude/skills/codegraph-explore/SKILL.md
@@ -44,12 +44,18 @@ This project has CodeGraph initialized (.codegraph/ exists). Use `codegraph_expl
 
 ## What to report back
 
-Keep the report under ~<<400–600>> words. Structure it as:
+**Handback contract — read this first.** Your final message is the ONLY thing passed back to the main session; everything you retrieved with `codegraph_explore` stays in your context, not the caller's. A source dump here is exactly what stalls the main session on handback. So:
+
+- Return a **summary, not source**. Never paste `codegraph_explore` / `codegraph_context` output, whole files, or multi-line source blocks into your report.
+- Cite code as `path/to/file.ext:line`. Quote at most ~10 lines total across the whole report, and only when the exact text IS the answer (a signature, a dispatch key, a regex).
+- Hard cap: keep the report under ~<<400–600>> words (per the thoroughness level) no matter how much source you read to get there.
+
+Structure it as:
 
 1. <<Primary deliverable — flow diagram / impact list / component map>>
-2. **Key functions** (file:line for each hop)
+2. **Key functions** — `file:line` for each hop (reference, don't quote)
 3. <<Secondary deliverables specific to the question>>
-4. **Benchmark notes at the end**: (a) total tool calls, (b) codegraph_* vs grep/read/glob breakdown, (c) whether CodeGraph gave you everything or you needed fallback and WHY, (d) anything CodeGraph missed or got wrong.
+4. **Benchmark notes** (counts only, no transcripts): (a) total tool calls, (b) codegraph_* vs grep/read/glob breakdown, (c) whether CodeGraph gave you everything or you needed fallback and WHY, (d) anything CodeGraph missed or got wrong.
 
 ## Honesty guardrails
 


### PR DESCRIPTION
## Problem

Spawning an Explore subagent for CodeGraph exploration caused a noticeable stall when it handed back to the main session. The `codegraph-explore` skill already capped the *written report* length, but nothing forbade the subagent from pasting `codegraph_explore` / `codegraph_context` **source sections** into its final message. Since a subagent's final message is the only thing injected into the main session's context, echoing those large source blocks forced a big prompt re-read on handback — the pause.

## Change

Two files in the CodeGraph subagent layer:

- **`.claude/skills/codegraph-explore/SKILL.md`** — the "What to report back" section now leads with an explicit **handback contract**: summary not source, `file:line` citations, ≤10 quoted lines total (only when the exact text is the answer), and no `codegraph_explore` / `codegraph_context` output in the final message. Thoroughness levels and the benchmark-notes instrumentation are preserved (benchmark notes clarified as counts only, no transcripts).
- **`.claude/rules/codegraph.md`** — adds a short cross-referencing note so the handback contract is discoverable from the rules file, pointing at the skill's "What to report back" section.

The subagent still uses `codegraph_explore` as its primary tool and reads full source internally — the change only governs what it sends *back*. Nothing changes on the CodeGraph MCP side, since its large-output tools are already funneled exclusively through the Explore subagent.

## Not touched

The global `CLAUDE.md` CodeGraph section (in `dhg-claude-config`) carries a similar spawn-prompt template that also lacks a handback contract. Left out of scope here; happy to mirror this fix there if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MyVGwkgxb6TQarPwSi6iFK

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyVGwkgxb6TQarPwSi6iFK)_